### PR TITLE
Workaround on false expire time

### DIFF
--- a/Cookie.php
+++ b/Cookie.php
@@ -71,7 +71,13 @@ class Cookie
         $this->httponly = (bool) $httponly;
 
         if (null !== $expires) {
-            $timestampAsDateTime = \DateTime::createFromFormat('U', $expires);
+
+            if($expires != false) {
+                $timestampAsDateTime = \DateTime::createFromFormat('U', $expires);
+            }  else {
+                $timestampAsDateTime = \DateTime::createFromFormat('U', strtotime('+5 minutes'));
+            }
+            
             if (false === $timestampAsDateTime) {
                 throw new \UnexpectedValueException(sprintf('The cookie expiration time "%s" is not valid.', $expires));
             }


### PR DESCRIPTION
Created a default method to create a timestamp in case expires time be false. In many apps, I don't why, the browser-kit creates an array with a value with false value, bit the request was made correctly.
