### PR TITLE
[BrowserKit] Allowing body content from GET with a content-type

### DIFF
--- a/HttpBrowser.php
+++ b/HttpBrowser.php
@@ -61,7 +61,7 @@ class HttpBrowser extends AbstractBrowser
      */
     private function getBodyAndExtraHeaders(Request $request, array $headers): array
     {
-        if (\in_array($request->getMethod(), ['GET', 'HEAD'])) {
+        if (($request->getMethod() == 'GET' && !isset($headers['content-type'])) || $request->getMethod() == 'HEAD') {
             return ['', []];
         }
 

--- a/Tests/HttpBrowserTest.php
+++ b/Tests/HttpBrowserTest.php
@@ -63,6 +63,10 @@ class HttpBrowserTest extends AbstractBrowserTest
             ['POST', 'http://example.com/', [], [], ['CONTENT_TYPE' => 'application/json'], '["content"]'],
             ['POST', 'http://example.com/', ['headers' => $defaultHeaders + ['content-type' => 'application/json'], 'body' => '["content"]', 'max_redirects' => 0]],
         ];
+        yield 'GET JSON' => [
+            ['GET', 'http://example.com/jsonrpc', [], [], ['CONTENT_TYPE' => 'application/json'], '["content"]'],
+            ['GET', 'http://example.com/jsonrpc', ['headers' => $defaultHeaders + ['content-type' => 'application/json'], 'body' => '["content"]', 'max_redirects' => 0]],
+        ];
     }
 
     public function testMultiPartRequestWithSingleFile()


### PR DESCRIPTION

Q | A
-- | --
Branch? | master
Bug fix? | no
New feature? | yes
Deprecations? | no
Tickets | /
License | MIT
Doc PR | /

This allows a GET request to sent a payload if it specifies a content-type in the HTTP header as per our conversation in the ticket [37609](https://github.com/symfony/symfony/issues/37609)
